### PR TITLE
remove complains when connection is already closed

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,6 +53,8 @@ function onReceiveError (info) {
   if (info.socketId in sockets) {
     sockets[info.socketId]._onReceiveError(info.resultCode)
   } else {
+    if (info.resultCode == -100) // net::ERR_CONNECTION_CLOSED
+      return
     console.error('Unknown socket id: ' + info.socketId)
   }
 }


### PR DESCRIPTION
When the socket has already been destroyed, there is no object in sockets[info.socketId]. But onReceiveError() is being called. This function complains that there is no such object. Therefore, we can safely ignore this error when the connection has already been closed.
