### PR TITLE
Chrome complains about unchecked error

### DIFF
--- a/index.js
+++ b/index.js
@@ -456,7 +456,8 @@ Socket.prototype.connect = function (options, cb) {
 
     chrome.sockets.tcp.connect(self.id, options.host, port, function (result) {
       if (result < 0) {
-        self.destroy(new Error('Socket ' + self.id + ' connect error ' + result))
+        self.destroy(new Error('Socket ' + self.id + ' connect error ' + result
+          + ': ' + chrome.runtime.lastError.message))
         return
       }
 


### PR DESCRIPTION
I'm getting the following error, when it cannot connect. chrome.runtime.lastError needs to be checked. Then this message goes away.
Unchecked runtime.lastError while running sockets.tcp.connect: net::ERR_CONNECTION_REFUSED
    at Object.callback
