### PR TITLE
launch custom chrome path in tests. launch and load absolute path

### DIFF
--- a/test/helper.js
+++ b/test/helper.js
@@ -5,7 +5,7 @@ var fs = require('fs')
 var once = require('once')
 var path = require('path')
 
-var CHROME = '/Applications/Google\\ Chrome\\ Canary.app/Contents/MacOS/Google\\ Chrome\\ Canary'
+var CHROME = process.env.CHROME||'/Applications/Google\\ Chrome\\ Canary.app/Contents/MacOS/Google\\ Chrome\\ Canary'
 var BUNDLE_PATH = path.join(__dirname, 'chrome-app/bundle.js')
 
 exports.browserify = function (filename, env, cb) {
@@ -24,7 +24,9 @@ exports.browserify = function (filename, env, cb) {
 }
 
 exports.launchBrowser = function () {
-  var command = CHROME + ' --load-and-launch-app=test/chrome-app'
+  // chrome 40.0.2188.2 won't open extensions without absolute path.
+  var app = path.join(__dirname, '..','test/chrome-app');
+  var command = CHROME + ' --load-and-launch-app='+app;
   var env = { cwd: path.join(__dirname, '..') }
 
   return cp.exec(command, env, function () {})


### PR DESCRIPTION
add support for specifing the path to the google-chrome executable via provess.env.CHROME.
- allows tests to be run on linux. etc
  updated load-and-launch-app to use absolute path to extension.
- chrome on linux was not loading the extension with relative path despite cwd being set correctly
  this could be related to my specific version of chrome and not the platform at all but change this works in all cases.
