### PR TITLE
Fix Socket().connect() API when used directly

### DIFF
--- a/index.js
+++ b/index.js
@@ -445,8 +445,11 @@ exports.Socket = Socket
  * @param  {function} cb
  * @return {Socket}   this socket (for chaining)
  */
-Socket.prototype.connect = function (options, cb) {
-  var self = this
+Socket.prototype.connect = function () {
+  var args    = normalizeConnectArgs(arguments)
+  var self    = this
+  var options = args[0]
+  var cb      = args[1]
 
   if (self._connecting)
     return

--- a/test/client/tcp-connect-direct.js
+++ b/test/client/tcp-connect-direct.js
@@ -1,0 +1,32 @@
+var net = require('../../')
+
+var PORT = Number(process.env.PORT)
+
+var client = new net.Socket()
+client.connect(PORT,'127.0.0.1')
+
+// If any errors are emitted, log them
+client.on('error', function (err) {
+  console.error(err.stack)
+})
+
+client.on('data', function (data) {
+  if (data.toString() === 'boop') {
+    client.write('pass')
+  } else {
+    client.write('fail')
+  }
+})
+
+client.write('beep')
+
+// TODO:
+// - test bytesWritten
+// - test bytesRead
+
+
+// streaming
+// var through = require('through')
+// client.pipe(through(function (data) {
+//   console.log(bops.to(data))
+// }))

--- a/test/tcp-connect.js
+++ b/test/tcp-connect.js
@@ -40,3 +40,41 @@ test('TCP connect works (echo test)', function (t) {
     server.listen(port)
   })
 })
+
+test('TCP connect works with direct API (echo test)', function (t) {
+  portfinder.getPort(function (err, port) {
+    t.error(err, 'Found free port')
+    var child
+
+    var server = net.createServer()
+
+    server.on('listening', function () {
+      var env = { PORT: port }
+      helper.browserify('tcp-connect-direct.js', env, function (err) {
+        t.error(err, 'Clean browserify build')
+        child = helper.launchBrowser()
+      })
+    })
+
+    var i = 0
+    server.on('connection', function (c) {
+      c.on('data', function (data) {
+        if (i === 0) {
+          t.equal(data.toString(), 'beep', 'Got beep')
+          c.write('boop', 'utf8')
+        } else if (i === 1) {
+          t.equal(data.toString(), 'pass', 'Boop was received')
+          c.end()
+          server.close()
+          child.kill()
+          t.end()
+        } else {
+          t.fail('TCP client sent unexpected data')
+        }
+        i += 1
+      })
+    })
+
+    server.listen(port)
+  })
+})


### PR DESCRIPTION
I noticed that this module does not work correctly when using the node `net` api as follows:

```js
var client = net.Socket();
client.connect(host,port);
```

It is designed properly to work with `net.connect()` and  `net.createConnection`, but not with this usage above.  I want to use `chrome-net` with other modules that use `net` in this way, so it's not as easy as just not using `chrome-net` in this way :)

I'm not sure this is the *best* way to fix the issue, but I wanted to just reuse the normalize method that was already there, and this seems to do the trick with minimal code changes.