### PR TITLE
Connect after listeners

### DIFF
--- a/index.js
+++ b/index.js
@@ -445,8 +445,11 @@ exports.Socket = Socket
  * @param  {function} cb
  * @return {Socket}   this socket (for chaining)
  */
-Socket.prototype.connect = function (options, cb) {
-  var self = this
+Socket.prototype.connect = function () {
+  var args    = normalizeConnectArgs(arguments)
+  var self    = this
+  var options = args[0]
+  var cb      = args[1]
 
   if (self._connecting)
     return

--- a/test/client/tcp-connect-direct.js
+++ b/test/client/tcp-connect-direct.js
@@ -1,0 +1,32 @@
+var net = require('../../')
+
+var PORT = Number(process.env.PORT)
+
+var client = new net.Socket()
+client.connect(PORT,'127.0.0.1')
+
+// If any errors are emitted, log them
+client.on('error', function (err) {
+  console.error(err.stack)
+})
+
+client.on('data', function (data) {
+  if (data.toString() === 'boop') {
+    client.write('pass')
+  } else {
+    client.write('fail')
+  }
+})
+
+client.write('beep')
+
+// TODO:
+// - test bytesWritten
+// - test bytesRead
+
+
+// streaming
+// var through = require('through')
+// client.pipe(through(function (data) {
+//   console.log(bops.to(data))
+// }))

--- a/test/client/tcp-connect-direct.js
+++ b/test/client/tcp-connect-direct.js
@@ -3,7 +3,6 @@ var net = require('../../')
 var PORT = Number(process.env.PORT)
 
 var client = new net.Socket()
-client.connect(PORT,'127.0.0.1')
 
 // If any errors are emitted, log them
 client.on('error', function (err) {
@@ -18,6 +17,7 @@ client.on('data', function (data) {
   }
 })
 
+client.connect(PORT,'127.0.0.1')
 client.write('beep')
 
 // TODO:

--- a/test/tcp-connect.js
+++ b/test/tcp-connect.js
@@ -40,3 +40,41 @@ test('TCP connect works (echo test)', function (t) {
     server.listen(port)
   })
 })
+
+test('TCP connect works with direct API (echo test)', function (t) {
+  portfinder.getPort(function (err, port) {
+    t.error(err, 'Found free port')
+    var child
+
+    var server = net.createServer()
+
+    server.on('listening', function () {
+      var env = { PORT: port }
+      helper.browserify('tcp-connect-direct.js', env, function (err) {
+        t.error(err, 'Clean browserify build')
+        child = helper.launchBrowser()
+      })
+    })
+
+    var i = 0
+    server.on('connection', function (c) {
+      c.on('data', function (data) {
+        if (i === 0) {
+          t.equal(data.toString(), 'beep', 'Got beep')
+          c.write('boop', 'utf8')
+        } else if (i === 1) {
+          t.equal(data.toString(), 'pass', 'Boop was received')
+          c.end()
+          server.close()
+          child.kill()
+          t.end()
+        } else {
+          t.fail('TCP client sent unexpected data')
+        }
+        i += 1
+      })
+    })
+
+    server.listen(port)
+  })
+})


### PR DESCRIPTION
I'm opening this as an issue b/c I don't fully understand what the problem is yet.  It seems like if you ever call `.on('data', function(data){ ... })` before calling `connect` on the `Socket()` object, it will fail.

I've changed the test here to display the issue (it doesn't actually fail since the tests dont seem to item out, but it will hang when it hits the issue).

It seems just listening to the 'data' event causes something to be called that tries to do something on the socket connection that hasn't actually been created yet (since `connect()` hasn't been called).  This pattern works on the vanilla node `net` package.

I PR'ed this on top of my other PR/branch (https://github.com/feross/chrome-net/pull/22) b/c it was easier to exhibit the behavior after that change, but just look at the second commit on this PR for the issue.