### PR TITLE
Merge in jscissr/net-chrome-apps

### DIFF
--- a/index.js
+++ b/index.js
@@ -900,7 +900,9 @@ Socket.prototype._destroy = function (exception, cb) {
   if (self.id) {
     delete sockets[self.id]
     chrome.sockets.tcp.close(self.id, function () {
-      self.emit('close', !!exception)
+      if (self.destroyed) {
+        self.emit('close', !!exception)
+      }
     })
     self.id = null
   }

--- a/index.js
+++ b/index.js
@@ -13,6 +13,8 @@ var EventEmitter = require('events').EventEmitter
 var inherits = require('inherits')
 var is = require('core-util-is')
 var stream = require('stream')
+var deprecate = require('util').deprecate
+var timers = require('timers')
 
 // Track open servers and sockets to route incoming sockets (via onAccept and onReceive)
 // to the right handlers.
@@ -145,10 +147,32 @@ function Server (/* [options], listener */) {
     }
   }
 
-  self._destroyed = false
   self._connections = 0
+
+  Object.defineProperty(self, 'connections', {
+    get: deprecate(function () {
+      return self._connections
+    }, 'connections property is deprecated. Use getConnections() method'),
+    set: deprecate(function (val) {
+      return (self._connections = val)
+    }, 'connections property is deprecated. Use getConnections() method'),
+    configurable: true, enumerable: false
+  })
+
+  self.id = null // a number > 0
+  self._connecting = false
+
+  self.allowHalfOpen = options.allowHalfOpen || false
+  self.pauseOnConnect = !!options.pauseOnConnect
+  self._address = null
+
+  self._host = null
+  self._port = null
+  self._backlog = null
 }
 exports.Server = Server
+
+Server.prototype._usingSlaves = false // not used
 
 /**
  * server.listen(port, [host], [backlog], [callback])
@@ -176,47 +200,141 @@ Server.prototype.listen = function (/* variable arguments... */) {
     self.once('listening', lastArg)
   }
 
-  // If port is invalid or undefined, bind to a random port.
-  var port = toNumber(arguments[0]) || 0
+  var port = toNumber(arguments[0])
 
   var address
-  if (arguments[1] == null ||
-      is.isFunction(arguments[1]) ||
-      is.isNumber(arguments[1])) {
-    // The first argument is the port, no IP given.
-    address = '0.0.0.0'
-  } else {
-    address = arguments[1]
-  }
 
   // The third optional argument is the backlog size.
   // When the ip is omitted it can be the second argument.
   var backlog = toNumber(arguments[1]) || toNumber(arguments[2]) || undefined
 
+  if (is.isObject(arguments[0])) {
+    var h = arguments[0]
+
+    if (h._handle || h.handle) {
+      throw new Error('handle is not supported in Chrome Apps.')
+    }
+    if (is.isNumber(h.fd) && h.fd >= 0) {
+      throw new Error('fd is not supported in Chrome Apps.')
+    }
+
+    // The first argument is a configuration object
+    if (h.backlog) {
+      backlog = h.backlog
+    }
+
+    if (is.isNumber(h.port)) {
+      address = h.host || null
+      port = h.port
+    } else if (h.path && isPipeName(h.path)) {
+      throw new Error('Pipes are not supported in Chrome Apps.')
+    } else {
+      throw new Error('Invalid listen argument: ' + h)
+    }
+  } else if (isPipeName(arguments[0])) {
+    // UNIX socket or Windows pipe.
+    throw new Error('Pipes are not supported in Chrome Apps.')
+  } else if (is.isUndefined(arguments[1]) ||
+             is.isFunction(arguments[1]) ||
+             is.isNumber(arguments[1])) {
+    // The first argument is the port, no IP given.
+    address = null
+  } else {
+    // The first argument is the port, the second an IP.
+    address = arguments[1]
+  }
+
+  // now do something with port, address, backlog
+
+  if (self.id) {
+    self.close()
+  }
+
+  // If port is invalid or undefined, bind to a random port.
+  self._port = port | 0
+  if (self._port < 0 || self._port > 65535) { // allow 0 for random port
+    throw new RangeError('port should be >= 0 and < 65536: ' + self._port)
+  }
+
+  self._host = address
+
+  var isAny6 = !self._host
+  if (isAny6) {
+    self._host = '::'
+  }
+
+  self._backlog = is.isNumber(backlog) ? backlog : undefined
+
+  self._connecting = true
+
   chrome.sockets.tcpServer.create(function (createInfo) {
-    self.id = createInfo.socketId
+    if (!self._connecting || self.id) {
+      ignoreLastError()
+      chrome.sockets.tcpServer.close(createInfo.socketId)
+      return
+    }
+    if (chrome.runtime.lastError) {
+      self.emit('error', new Error(chrome.runtime.lastError.message))
+      return
+    }
 
-    chrome.sockets.tcpServer.listen(self.id, address, port, backlog, function (result) {
-      if (result < 0) {
-        var err = new Error('Socket ' + self.id + ' failed to listen. ' +
-          chrome.runtime.lastError.message)
-        err.code = 'EADDRINUSE'
-        self.emit('error', err)
-        self._destroy()
-        return
-      }
+    var socketId = self.id = createInfo.socketId
+    servers[self.id] = self
 
-      servers[self.id] = self
+    function listen () {
+      chrome.sockets.tcpServer.listen(self.id, self._host, self._port,
+          self._backlog, function (result) {
+        // callback may be after close
+        if (self.id !== socketId) {
+          ignoreLastError()
+          return
+        }
+        if (result !== 0 && isAny6) {
+          ignoreLastError()
+          self._host = '0.0.0.0' // try IPv4
+          isAny6 = false
+          return listen()
+        }
 
-      chrome.sockets.tcpServer.getInfo(self.id, function (socketInfo) {
-        self._address = socketInfo.localAddress
-        self._port = socketInfo.localPort
-        self.emit('listening')
+        self._onListen(result)
       })
-    })
+    }
+    listen()
   })
 
   return self
+}
+
+Server.prototype._onListen = function (result) {
+  var self = this
+  self._connecting = false
+
+  if (result === 0) {
+    var idBefore = self.id
+    chrome.sockets.tcpServer.getInfo(self.id, function (info) {
+      if (self.id !== idBefore) {
+        ignoreLastError()
+        return
+      }
+      if (chrome.runtime.lastError) {
+        self._onListen(-2) // net::ERR_FAILED
+        return
+      }
+
+      self._address = {
+        port: info.localPort,
+        family: info.localAddress &&
+          info.localAddress.indexOf(':') !== -1 ? 'IPv6' : 'IPv4',
+        address: info.localAddress
+      }
+      self.emit('listening')
+    })
+  } else {
+    self.emit('error', errnoException(result, 'listen'))
+    chrome.sockets.tcpServer.close(self.id)
+    delete servers[self.id]
+    self.id = null
+  }
 }
 
 Server.prototype._onAccept = function (clientSocketId) {
@@ -225,8 +343,7 @@ Server.prototype._onAccept = function (clientSocketId) {
   // Set the `maxConnections` property to reject connections when the server's
   // connection count gets high.
   if (self.maxConnections && self._connections >= self.maxConnections) {
-    chrome.sockets.tcpServer.disconnect(clientSocketId)
-    chrome.sockets.tcpServer.close(clientSocketId)
+    chrome.sockets.tcp.close(clientSocketId)
     console.warn('Rejected connection - hit `maxConnections` limit')
     return
   }
@@ -235,22 +352,19 @@ Server.prototype._onAccept = function (clientSocketId) {
 
   var acceptedSocket = new Socket({
     server: self,
-    id: clientSocketId
+    id: clientSocketId,
+    allowHalfOpen: self.allowHalfOpen,
+    pauseOnCreate: self.pauseOnConnect
   })
   acceptedSocket.on('connect', function () {
     self.emit('connection', acceptedSocket)
   })
-
-  chrome.sockets.tcp.setPaused(clientSocketId, false)
 }
 
 Server.prototype._onAcceptError = function (resultCode) {
   var self = this
-  var err = new Error('Socket ' + self.id + ' failed to accept (' +
-    resultCode + ')')
-  err.code = 'EPIPE' // TODO: this may not be correct
-  self.emit('error', err)
-  self._destroy()
+  self.emit('error', errnoException(resultCode, 'accept'))
+  self.close()
 }
 
 /**
@@ -262,24 +376,42 @@ Server.prototype._onAcceptError = function (resultCode) {
  */
 Server.prototype.close = function (callback) {
   var self = this
-  self._destroy(callback)
+
+  if (callback) {
+    if (!self.id) {
+      self.once('close', function () {
+        callback(new Error('Not running'))
+      })
+    } else {
+      self.once('close', callback)
+    }
+  }
+
+  if (self.id) {
+    chrome.sockets.tcpServer.close(self.id)
+    delete servers[self.id]
+    self.id = null
+  }
+  self._address = null
+  self._connecting = false
+
+  self._emitCloseIfDrained()
+
+  return self
 }
 
-Server.prototype._destroy = function (exception, cb) {
+Server.prototype._emitCloseIfDrained = function () {
   var self = this
 
-  if (self._destroyed) return
+  if (self.id || self._connecting || self._connections) {
+    return
+  }
 
-  if (cb) this.once('close', cb)
-
-  this._destroyed = true
-  this._connections = 0
-  delete servers[self.id]
-
-  chrome.sockets.tcpServer.disconnect(self.id, function () {
-    chrome.sockets.tcpServer.close(self.id, function () {
-      self.emit('close')
-    })
+  process.nextTick(function () {
+    if (self.id || self._connecting || self._connections) {
+      return
+    }
+    self.emit('close')
   })
 }
 
@@ -291,12 +423,7 @@ Server.prototype._destroy = function (exception, cb) {
  * @return {Object} information
  */
 Server.prototype.address = function () {
-  var self = this
-  return {
-    address: self._address,
-    port: self._port,
-    family: 'IPv4'
-  }
+  return this._address
 }
 
 Server.prototype.unref = function () {
@@ -392,26 +519,53 @@ function Socket (options) {
   var self = this
   if (!(self instanceof Socket)) return new Socket(options)
 
-  if (is.isUndefined(options)) options = {}
+  if (is.isNumber(options)) {
+    options = { fd: options } // Legacy interface.
+  } else if (is.isUndefined(options)) {
+    options = {}
+  }
 
+  if (options.handle) {
+    throw new Error('handle is not supported in Chrome Apps.')
+  } else if (!is.isUndefined(options.fd)) {
+    throw new Error('fd is not supported in Chrome Apps.')
+  }
+
+  options.decodeStrings = true
+  options.objectMode = false
   stream.Duplex.call(self, options)
 
   self.destroyed = false
-  self.errorEmitted = false
-  self.readable = self.writable = false
-
-  // The amount of received bytes.
-  self.bytesRead = 0
-
-  self._bytesDispatched = 0
-  self._connecting = false
+  self._hadError = false // Used by _http_client.js
+  self.id = null // a number > 0
+  self._parent = null
+  self._host = null
+  self._port = null
+  self._pendingData = null
 
   self.ondata = null
   self.onend = null
 
+  self._init()
+  self._reset()
+
+  // default to *not* allowing half open sockets
+  // Note: this is not possible in Chrome Apps, see https://crbug.com/124952
+  self.allowHalfOpen = options.allowHalfOpen || false
+
+  // shut down the socket when we're finished with it.
+  self.on('finish', self.destroy)
+
   if (options.server) {
     self.server = options.server
     self.id = options.id
+    sockets[self.id] = self
+
+    if (options.pauseOnCreate) {
+      // stop the handle from reading and pause the stream
+      // (Already paused in Chrome version)
+      self._readableState.flowing = false
+    }
 
     // For incoming sockets (from server), it's already connected.
     self._connecting = true
@@ -419,6 +573,27 @@ function Socket (options) {
   }
 }
 exports.Socket = Socket
+
+// called when creating new Socket, or when re-using a closed Socket
+Socket.prototype._init = function () {
+  var self = this
+
+  // The amount of received bytes.
+  self.bytesRead = 0
+
+  self._bytesDispatched = 0
+}
+
+// called when creating new Socket, or when closing a Socket
+Socket.prototype._reset = function () {
+  var self = this
+
+  self.remoteAddress = self.remotePort =
+      self.localAddress = self.localPort = null
+  self.remoteFamily = 'IPv4'
+  self.readable = self.writable = false
+  self._connecting = false
+}
 
 /**
  * socket.connect(port, [host], [connectListener])
@@ -450,32 +625,73 @@ Socket.prototype.connect = function () {
   var options = args[0]
   var cb = args[1]
 
-  if (self._connecting) return
-  self._connecting = true
+  if (options.path) {
+    throw new Error('Pipes are not supported in Chrome Apps.')
+  }
 
-  var port = Number(options.port)
+  if (self.id) {
+    // already connected, destroy and connect again
+    self.destroy()
+  }
+
+  if (self.destroyed) {
+    self._readableState.reading = false
+    self._readableState.ended = false
+    self._readableState.endEmitted = false
+    self._writableState.ended = false
+    self._writableState.ending = false
+    self._writableState.finished = false
+    self._writableState.errorEmitted = false
+    self._writableState.length = 0
+    self.destroyed = false
+  }
+
+  self._connecting = true
+  self.writable = true
+
+  self._host = options.host || 'localhost'
+  self._port = Number(options.port)
+
+  if (self._port < 0 || self._port > 65535 || isNaN(self._port)) {
+    throw new RangeError('port should be >= 0 and < 65536: ' + options.port)
+  }
+
+  self._init()
+
+  self._unrefTimer()
 
   if (is.isFunction(cb)) {
     self.once('connect', cb)
   }
 
   chrome.sockets.tcp.create(function (createInfo) {
-    if (self.destroyed) {
+    if (!self._connecting || self.id) {
+      ignoreLastError()
       chrome.sockets.tcp.close(createInfo.socketId)
+      return
+    }
+    if (chrome.runtime.lastError) {
+      self.destroy(new Error(chrome.runtime.lastError.message))
       return
     }
 
     self.id = createInfo.socketId
+    sockets[self.id] = self
 
-    chrome.sockets.tcp.connect(self.id, options.host, port, function (result) {
-      if (result < 0) {
-        var err = new Error('Socket ' + self.id + ' connect error ' + result +
-          ': ' + chrome.runtime.lastError.message)
-        err.code = 'ECONNREFUSED'
-        self.destroy(err)
+    chrome.sockets.tcp.setPaused(self.id, true)
+
+    chrome.sockets.tcp.connect(self.id, self._host, self._port, function (result) {
+      // callback may come after call to destroy
+      if (self.id !== createInfo.socketId) {
+        ignoreLastError()
+        return
+      }
+      if (result !== 0) {
+        self.destroy(errnoException(result, 'connect'))
         return
       }
 
+      self._unrefTimer()
       self._onConnect()
     })
   })
@@ -486,20 +702,32 @@ Socket.prototype.connect = function () {
 Socket.prototype._onConnect = function () {
   var self = this
 
-  sockets[self.id] = self
+  var idBefore = self.id
   chrome.sockets.tcp.getInfo(self.id, function (result) {
+    if (self.id !== idBefore) {
+      ignoreLastError()
+      return
+    }
+    if (chrome.runtime.lastError) {
+      self.destroy(new Error(chrome.runtime.lastError.message))
+      return
+    }
+
     self.remoteAddress = result.peerAddress
+    self.remoteFamily = result.peerAddress &&
+        result.peerAddress.indexOf(':') !== -1 ? 'IPv6' : 'IPv4'
     self.remotePort = result.peerPort
     self.localAddress = result.localAddress
     self.localPort = result.localPort
 
     self._connecting = false
-    self.readable = self.writable = true
+    self.readable = true
 
     self.emit('connect')
     // start the first read, or get an immediate EOF.
     // this doesn't actually consume any bytes, because len=0
-    self.read(0)
+    // TODO: replace _readableState.flowing with isPaused() after https://github.com/substack/node-browserify/issues/1341
+    if (self._readableState.flowing) self.read(0)
   })
 }
 
@@ -510,68 +738,60 @@ Socket.prototype._onConnect = function () {
 Object.defineProperty(Socket.prototype, 'bufferSize', {
   get: function () {
     var self = this
-    if (self._pendingData) return self._pendingData.length
-    else return 0 // Unfortunately, chrome.socket does not make this info available
+    if (self.id) {
+      var bytes = this._writableState.length
+      if (self._pendingData) bytes += self._pendingData.length
+      return bytes
+    }
   }
 })
 
-/**
- * Sends data on the socket. The second parameter specifies the encoding in
- * the case of a string--it defaults to UTF8 encoding.
- *
- * Returns true if the entire data was flushed successfully to the kernel
- * buffer. Returns false if all or part of the data was queued in user memory.
- * 'drain' will be emitted when the buffer is again free.
- *
- * The optional callback parameter will be executed when the data is finally
- * written out - this may not be immediately.
- *
- * @param  {Buffer|Arrayish|string} chunk
- * @param  {string} [encoding]
- * @param  {function} [callback]
- * @return {boolean}             flushed to kernel completely?
- */
-Socket.prototype.write = function (chunk, encoding, callback) {
+Socket.prototype.end = function (data, encoding) {
   var self = this
-  if (!Buffer.isBuffer(chunk)) chunk = new Buffer(chunk, encoding)
-
-  return stream.Duplex.prototype.write.call(self, chunk, encoding, callback)
+  stream.Duplex.prototype.end.call(self, data, encoding)
+  self.writable = false
 }
 
-Socket.prototype._write = function (buffer, encoding, callback) {
+Socket.prototype._write = function (chunk, encoding, callback) {
   var self = this
   if (!callback) callback = function () {}
 
-  if (!self.writable) {
-    self._pendingData = buffer
-    self._pendingEncoding = encoding
+  if (self._connecting) {
+    self._pendingData = chunk
     self.once('connect', function () {
-      self._write(buffer, encoding, callback)
+      self._write(chunk, encoding, callback)
     })
     return
   }
   self._pendingData = null
-  self._pendingEncoding = null
 
-  // assuming buffer is browser implementation (`buffer` package on npm)
-  var buf = buffer.buffer
-  if (buffer.byteOffset || buffer.byteLength !== buf.byteLength) {
-    buf = buf.slice(buffer.byteOffset, buffer.byteOffset + buffer.byteLength)
+  if (!this.id) {
+    callback(new Error('This socket is closed.'))
+    return
   }
 
-  chrome.sockets.tcp.send(self.id, buf, function (sendInfo) {
+  // assuming buffer is browser implementation (`buffer` package on npm)
+  var buffer = chunk.buffer
+  if (chunk.byteOffset || chunk.byteLength !== buffer.byteLength) {
+    buffer = buffer.slice(chunk.byteOffset, chunk.byteOffset + chunk.byteLength)
+  }
+
+  var idBefore = self.id
+  chrome.sockets.tcp.send(self.id, buffer, function (sendInfo) {
+    if (self.id !== idBefore) {
+      ignoreLastError()
+      return
+    }
+
     if (sendInfo.resultCode < 0) {
-      var err = new Error('Socket ' + self.id + ' write error: ' + sendInfo.resultCode)
-      err.code = 'EPIPE'
-      callback(err)
-      self.destroy(err)
+      self.destroy(errnoException(sendInfo.resultCode, 'write'), callback)
     } else {
-      self._resetTimeout()
+      self._unrefTimer()
       callback(null)
     }
   })
 
-  self._bytesDispatched += buffer.length
+  self._bytesDispatched += chunk.length
 }
 
 Socket.prototype._read = function (bufferSize) {
@@ -582,17 +802,32 @@ Socket.prototype._read = function (bufferSize) {
   }
 
   chrome.sockets.tcp.setPaused(self.id, false)
+
+  var idBefore = self.id
+  chrome.sockets.tcp.getInfo(self.id, function (result) {
+    if (self.id !== idBefore) {
+      ignoreLastError()
+      return
+    }
+    if (chrome.runtime.lastError || !result.connected) {
+      self._onReceiveError(-15) // workaround for https://crbug.com/518161
+    }
+  })
 }
 
 Socket.prototype._onReceive = function (data) {
   var self = this
-  var buffer = new Buffer(new Uint8Array(data))
+  // assuming buffer is browser implementation (`buffer` package on npm)
+  var buffer = Buffer._augment(new Uint8Array(data))
   var offset = self.bytesRead
 
   self.bytesRead += buffer.length
-  self._resetTimeout()
+  self._unrefTimer()
 
-  if (self.ondata) self.ondata(buffer, offset, self.bytesRead)
+  if (self.ondata) {
+    console.error('socket.ondata = func is non-standard, use socket.on(\'data\', func)')
+    self.ondata(buffer, offset, self.bytesRead)
+  }
   if (!self.push(buffer)) { // if returns false, then apply backpressure
     chrome.sockets.tcp.setPaused(self.id, true)
   }
@@ -600,14 +835,15 @@ Socket.prototype._onReceive = function (data) {
 
 Socket.prototype._onReceiveError = function (resultCode) {
   var self = this
-  if (resultCode === -100) {
-    if (self.onend) self.once('end', self.onend)
+  if (resultCode === -100) { // net::ERR_CONNECTION_CLOSED
+    if (self.onend) {
+      console.error('socket.onend = func is non-standard, use socket.on(\'end\', func)')
+      self.once('end', self.onend)
+    }
     self.push(null)
     self.destroy()
   } else if (resultCode < 0) {
-    var err = new Error('Socket ' + self.id + ' receive error ' + resultCode)
-    err.code = 'EPIPE' // TODO: this may not be correct
-    self.destroy(err)
+    self.destroy(errnoException(resultCode, 'read'))
   }
 }
 
@@ -618,19 +854,7 @@ Socket.prototype._onReceiveError = function (resultCode) {
 Object.defineProperty(Socket.prototype, 'bytesWritten', {
   get: function () {
     var self = this
-    var bytes = self._bytesDispatched
-
-    self._writableState.toArrayBuffer().forEach(function (el) {
-      if (Buffer.isBuffer(el.chunk)) bytes += el.chunk.length
-      else bytes += new Buffer(el.chunk, el.encoding).length
-    })
-
-    if (self._pendingData) {
-      if (Buffer.isBuffer(self._pendingData)) bytes += self._pendingData.length
-      else bytes += Buffer.byteLength(self._pendingData, self._pendingEncoding)
-    }
-
-    return bytes
+    if (self.id) return self._bytesDispatched + self.bufferSize
   }
 })
 
@@ -644,11 +868,11 @@ Socket.prototype._destroy = function (exception, cb) {
 
   function fireErrorCallbacks () {
     if (cb) cb(exception)
-    if (exception && !self.errorEmitted) {
+    if (exception && !self._writableState.errorEmitted) {
       process.nextTick(function () {
         self.emit('error', exception)
       })
-      self.errorEmitted = true
+      self._writableState.errorEmitted = true
     }
   }
 
@@ -658,26 +882,30 @@ Socket.prototype._destroy = function (exception, cb) {
     return
   }
 
-  if (this.server) {
-    this.server._connections -= 1
+  if (self.server) {
+    self.server._connections -= 1
+    if (self.server._emitCloseIfDrained) self.server._emitCloseIfDrained()
+    self.server = null
   }
 
-  self._connecting = false
-  this.readable = this.writable = false
-  self.destroyed = true
-  delete sockets[self.id]
+  self._reset()
 
-  // if _destroy() has been called before chrome.sockets.tcp.create()
+  for (var s = self; s !== null; s = s._parent) timers.unenroll(s)
+
+  self.destroyed = true
+
+  // If _destroy() has been called before chrome.sockets.tcp.create()
   // callback, we don't have an id. Therefore we don't need to close
   // or disconnect
   if (self.id) {
-    chrome.sockets.tcp.disconnect(self.id, function () {
-      chrome.sockets.tcp.close(self.id, function () {
-        self.emit('close', !!exception)
-        fireErrorCallbacks()
-      })
+    delete sockets[self.id]
+    chrome.sockets.tcp.close(self.id, function () {
+      self.emit('close', !!exception)
     })
+    self.id = null
   }
+
+  fireErrorCallbacks()
 }
 
 Socket.prototype.destroySoon = function () {
@@ -686,7 +914,6 @@ Socket.prototype.destroySoon = function () {
   if (self.writable) self.end()
 
   if (self._writableState.finished) self.destroy()
-  else self.once('finish', self._destroy.bind(self))
 }
 
 /**
@@ -704,25 +931,28 @@ Socket.prototype.destroySoon = function () {
  */
 Socket.prototype.setTimeout = function (timeout, callback) {
   var self = this
-  if (callback) self.once('timeout', callback)
-  self._timeoutMs = timeout
-  self._resetTimeout()
+
+  if (timeout === 0) {
+    timers.unenroll(self)
+    if (callback) {
+      self.removeListener('timeout', callback)
+    }
+  } else {
+    timers.enroll(self, timeout)
+    timers._unrefActive(self)
+    if (callback) {
+      self.once('timeout', callback)
+    }
+  }
 }
 
 Socket.prototype._onTimeout = function () {
-  var self = this
-  self._timeout = null
-  self._timeoutMs = 0
-  self.emit('timeout')
+  this.emit('timeout')
 }
 
-Socket.prototype._resetTimeout = function () {
-  var self = this
-  if (self._timeout) {
-    clearTimeout(self._timeout)
-  }
-  if (self._timeoutMs) {
-    self._timeout = setTimeout(self._onTimeout.bind(self), self._timeoutMs)
+Socket.prototype._unrefTimer = function unrefTimer () {
+  for (var s = this; s !== null; s = s._parent) {
+    timers._unrefActive(s)
   }
 }
 
@@ -741,10 +971,11 @@ Socket.prototype._resetTimeout = function () {
  */
 Socket.prototype.setNoDelay = function (noDelay, callback) {
   var self = this
-  // backwards compatibility: assume true when `enable` is omitted
-  noDelay = is.isUndefined(noDelay) ? true : !!noDelay
-  if (!callback) callback = function () {}
-  chrome.sockets.tcp.setNoDelay(self.id, noDelay, callback)
+  if (self.id) {
+    // backwards compatibility: assume true when `enable` is omitted
+    noDelay = is.isUndefined(noDelay) ? true : !!noDelay
+    chrome.sockets.tcp.setNoDelay(self.id, noDelay, chromeCallbackWrap(callback))
+  }
 }
 
 /**
@@ -767,9 +998,10 @@ Socket.prototype.setNoDelay = function (noDelay, callback) {
  */
 Socket.prototype.setKeepAlive = function (enable, initialDelay, callback) {
   var self = this
-  if (!callback) callback = function () {}
-  chrome.sockets.tcp.setKeepAlive(self.id, !!enable, ~~(initialDelay / 1000),
-      callback)
+  if (self.id) {
+    chrome.sockets.tcp.setKeepAlive(self.id, !!enable, ~~(initialDelay / 1000),
+        chromeCallbackWrap(callback))
+  }
 }
 
 /**
@@ -784,7 +1016,8 @@ Socket.prototype.address = function () {
   return {
     address: self.localAddress,
     port: self.localPort,
-    family: 'IPv4'
+    family: self.localAddress &&
+      self.localAddress.indexOf(':') !== -1 ? 'IPv6' : 'IPv4'
   }
 }
 
@@ -838,13 +1071,14 @@ function normalizeConnectArgs (args) {
   if (is.isObject(args[0])) {
     // connect(options, [cb])
     options = args[0]
+  } else if (isPipeName(args[0])) {
+    // connect(path, [cb])
+    throw new Error('Pipes are not supported in Chrome Apps.')
   } else {
     // connect(port, [host], [cb])
     options.port = args[0]
     if (is.isString(args[1])) {
       options.host = args[1]
-    } else {
-      options.host = '127.0.0.1'
     }
   }
 
@@ -854,4 +1088,65 @@ function normalizeConnectArgs (args) {
 
 function toNumber (x) {
   return (x = Number(x)) >= 0 ? x : false
+}
+
+function isPipeName (s) {
+  return is.isString(s) && toNumber(s) === false
+}
+
+ // This prevents "Unchecked runtime.lastError" errors
+function ignoreLastError () {
+  chrome.runtime.lastError // call the getter function
+}
+
+function chromeCallbackWrap (callback) {
+  return function () {
+    var error
+    if (chrome.runtime.lastError) {
+      console.error(chrome.runtime.lastError.message)
+      error = new Error(chrome.runtime.lastError.message)
+    }
+    if (callback) callback(error)
+  }
+}
+
+// Full list of possible error codes: https://code.google.com/p/chrome-browser/source/browse/trunk/src/net/base/net_error_list.h
+// TODO: Try to reproduce errors in both node & Chrome Apps and extend this list
+//       (what conditions lead to EPIPE?)
+var errorChromeToUv = {
+  '-10': 'EACCES',
+  '-22': 'EACCES',
+  '-138': 'EACCES',
+  '-147': 'EADDRINUSE',
+  '-108': 'EADDRNOTAVAIL',
+  '-103': 'ECONNABORTED',
+  '-102': 'ECONNREFUSED',
+  '-101': 'ECONNRESET',
+  '-16': 'EEXIST',
+  '-8': 'EFBIG',
+  '-109': 'EHOSTUNREACH',
+  '-4': 'EINVAL',
+  '-23': 'EISCONN',
+  '-6': 'ENOENT',
+  '-13': 'ENOMEM',
+  '-106': 'ENONET',
+  '-18': 'ENOSPC',
+  '-11': 'ENOSYS',
+  '-15': 'ENOTCONN',
+  '-105': 'ENOTFOUND',
+  '-118': 'ETIMEDOUT',
+  '-100': 'EOF'
+}
+function errnoException (err, syscall) {
+  var uvCode = errorChromeToUv[err] || 'UNKNOWN'
+  var message = syscall + ' ' + err
+  if (chrome.runtime.lastError) {
+    message += ' ' + chrome.runtime.lastError.message
+  }
+  message += ' (mapped uv code: ' + uvCode + ')'
+  var e = new Error(message)
+  e.code = e.errno = uvCode
+  // TODO: expose chrome error code; what property name?
+  e.syscall = syscall
+  return e
 }

--- a/index.js
+++ b/index.js
@@ -11,7 +11,6 @@
 
 var EventEmitter = require('events').EventEmitter
 var inherits = require('inherits')
-var ipaddr = require('ipaddr.js')
 var is = require('core-util-is')
 var stream = require('stream')
 
@@ -814,31 +813,15 @@ Socket.prototype.ref = function () {
 // EXPORTED HELPERS
 //
 
-exports.isIP = function (input) {
-  try {
-    ipaddr.parse(input)
-  } catch (e) {
-    return false
-  }
-  return true
-}
+// Source: https://developers.google.com/web/fundamentals/input/form/provide-real-time-validation#use-these-attributes-to-validate-input
+var IPv4Regex = /^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/
+var IPv6Regex = /^(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]).){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]).){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))$/
 
-exports.isIPv4 = function (input) {
-  try {
-    var parsed = ipaddr.parse(input)
-    return (parsed.kind() === 'ipv4')
-  } catch (e) {
-    return false
-  }
-}
+exports.isIPv4 = IPv4Regex.test.bind(IPv4Regex)
+exports.isIPv6 = IPv6Regex.test.bind(IPv6Regex)
 
-exports.isIPv6 = function (input) {
-  try {
-    var parsed = ipaddr.parse(input)
-    return (parsed.kind() === 'ipv6')
-  } catch (e) {
-    return false
-  }
+exports.isIP = function (ip) {
+  return exports.isIPv4(ip) ? 4 : exports.isIPv6(ip) ? 6 : 0
 }
 
 //

--- a/package.json
+++ b/package.json
@@ -14,13 +14,13 @@
     "inherits": "^2.0.1"
   },
   "devDependencies": {
-    "browserify": "^10.1.0",
+    "browserify": "^11.0.1",
     "chrome-dgram": "^2.0.6",
     "envify": "^3.2.0",
     "once": "1.x",
     "portfinder": "0.x",
     "run-auto": "^1.1.3",
-    "standard": "^4.5.2",
+    "standard": "^5.0.2",
     "tape": "^4.0.0",
     "through": "2.x"
   },

--- a/package.json
+++ b/package.json
@@ -11,8 +11,7 @@
   ],
   "dependencies": {
     "core-util-is": "~1.0.1",
-    "inherits": "^2.0.1",
-    "ipaddr.js": "^1.0.1"
+    "inherits": "^2.0.1"
   },
   "devDependencies": {
     "browserify": "^10.1.0",

--- a/test/client/tape-disconnect.js
+++ b/test/client/tape-disconnect.js
@@ -1,0 +1,78 @@
+var test = require('tape')
+var net = require('net')
+
+var PORT0 = Number(process.env.PORT0)
+
+test('disconnect client socket with wait', function (t) {
+  var server = net.createServer().listen(PORT0, '127.0.0.1')
+  server.once('listening', function () {
+    var socket = net.connect(PORT0, '127.0.0.1')
+    socket.once('connect', function () {
+      setTimeout(function () {
+        socket.destroy()
+      }, 500)
+    })
+  })
+  server.on('connection', function (con) {
+    con.resume() // allow FIN to be received
+    con.on('close', function () {
+      server.close()
+      t.end()
+    })
+  })
+})
+
+test('disconnect server socket with wait', function (t) {
+  var server = net.createServer().listen(PORT0, '127.0.0.1')
+  server.once('listening', function () {
+    var socket = net.connect(PORT0, '127.0.0.1')
+    socket.once('connect', function () {
+      socket.resume() // allow FIN to be received
+    })
+    socket.on('close', function () {
+      server.close()
+      t.end()
+    })
+  })
+  server.on('connection', function (con) {
+    setTimeout(function () {
+      con.destroy()
+    }, 500)
+  })
+})
+
+test('disconnect client socket', function (t) {
+  var server = net.createServer().listen(PORT0, '127.0.0.1')
+  server.once('listening', function () {
+    var socket = net.connect(PORT0, '127.0.0.1')
+    socket.once('connect', function () {
+      socket.destroy()
+    })
+  })
+  server.on('connection', function (con) {
+    con.resume() // allow FIN to be received
+    con.on('close', function () {
+      server.close()
+      t.end()
+    })
+    con.on('error', function () {})
+  })
+})
+
+test('disconnect server socket', function (t) {
+  var server = net.createServer().listen(PORT0, '127.0.0.1')
+  server.once('listening', function () {
+    var socket = net.connect(PORT0, '127.0.0.1')
+    socket.once('connect', function () {
+      socket.resume() // allow FIN to be received
+    })
+    socket.on('close', function () {
+      server.close()
+      t.end()
+    })
+    socket.on('error', function () {})
+  })
+  server.on('connection', function (con) {
+    con.destroy()
+  })
+})

--- a/test/client/tape-edge-cases.js
+++ b/test/client/tape-edge-cases.js
@@ -1,0 +1,102 @@
+var test = require('tape')
+var net = require('net')
+
+var PORT0 = Number(process.env.PORT0)
+var PORT1 = Number(process.env.PORT1)
+
+// listen
+
+test('listen on already listening server', function (t) {
+  var server = net.createServer()
+  server.listen(0, '127.0.0.1')
+  server.once('listening', function () {
+    t.ok(server.address().port, 'a port was assigned')
+    server.listen(server.address().port, '127.0.0.1')
+    server.once('listening', function () {
+      server.close()
+      t.end()
+    })
+  })
+  server.on('error', function (error) {
+    t.error(error, 'should not trigger EADDRINUSE')
+  })
+})
+
+test('second listen call overrides first', function (t) {
+  var server = net.createServer()
+  server.listen(PORT0, '127.0.0.1')
+  server.listen(PORT1, '127.0.0.1')
+  server.once('listening', function () {
+    t.equal(server.address().port, PORT1)
+    server.close()
+    t.end()
+  })
+})
+
+test('can cancel listen call', function (t) {
+  var server = net.createServer()
+  server.listen(PORT0, '127.0.0.1')
+  server.close()
+  server.once('listening', function () {
+    t.fail('shouldn\'t be listening')
+  })
+  setTimeout(function () {
+    t.end()
+  }, 400)
+})
+
+// connect
+
+test('connect on already connected socket', function (t) {
+  var server = net.createServer().listen(PORT0, '127.0.0.1')
+  server.on('connection', function (con) {
+    con.resume() // allow FIN to be received
+  })
+  server.once('listening', function () {
+    var socket = net.connect(PORT0, '127.0.0.1')
+    socket.once('connect', function () {
+      socket.connect(PORT0, '127.0.0.1')
+      socket.once('connect', function () {
+        socket.destroy()
+        server.close()
+        server.on('close', function () { // ensure all connections are closed
+          t.end()
+        })
+      })
+    })
+    socket.on('error', function (error) {
+      t.error(error, 'should not trigger EADDRINUSE')
+    })
+  })
+})
+
+test('second connect call overrides first', function (t) {
+  var server = net.createServer().listen(PORT1, '127.0.0.1')
+  server.once('listening', function () {
+    var socket = net.connect(PORT0, '127.0.0.1')
+    socket.connect(PORT1, '127.0.0.1')
+    socket.once('connect', function () {
+      t.equal(socket.remotePort, PORT1)
+      socket.destroy()
+      server.close()
+      t.end()
+    })
+    socket.on('error', function (error) {
+      t.error(error)
+    })
+  })
+})
+
+test('can cancel connect call', function (t) {
+  var socket = net.connect(PORT0, '127.0.0.1')
+  socket.destroy()
+  socket.once('connect', function () {
+    t.fail('shouldn\'t be connected')
+  })
+  socket.on('error', function (error) {
+    t.error(error)
+  })
+  setTimeout(function () {
+    t.end()
+  }, 400)
+})

--- a/test/client/tape-helper.js
+++ b/test/client/tape-helper.js
@@ -1,0 +1,19 @@
+var test = require('tape')
+var net = require('net')
+
+var TAPE_PORT = Number(process.env.TAPE_PORT)
+
+var con = net.connect(TAPE_PORT, '127.0.0.1')
+
+var success = false
+test.createStream().on('data', function (log) {
+  con.write(JSON.stringify({op: 'log', log: log.toString()}))
+  success = log === '\n# ok\n'
+}).on('end', function () {
+  con.write(JSON.stringify({op: 'end', success: success}))
+  con.end()
+})
+
+require('./tape-tcp.js')
+require('./tape-disconnect.js')
+require('./tape-edge-cases.js')

--- a/test/client/tape-tcp.js
+++ b/test/client/tape-tcp.js
@@ -1,0 +1,161 @@
+var test = require('tape')
+var net = require('net')
+
+var PORT0 = Number(process.env.PORT0)
+
+test('TCP listen', function (t) {
+  t.throws(function () {
+    net.createServer().listen({fd: 0})
+  }, /fd is not supported/, 'throws when trying to use named pipes')
+  t.throws(function () {
+    net.createServer().listen({path: 'pipename'})
+  }, /Pipes are not supported/, 'throws when trying to use named pipes')
+  t.throws(function () {
+    net.createServer().listen(65536)
+  }, /port should be >= 0 and < 65536/, 'throws when using invalid port 65536')
+  t.end()
+})
+
+test('TCP connect', function (t) {
+  t.throws(function () {
+    net.connect('pipename')
+  }, /Pipes are not supported/, 'throws when trying to use named pipes')
+  t.throws(function () {
+    net.connect(65536)
+  }, /port should be >= 0 and < 65536/, 'throws when using invalid port 65536')
+  t.end()
+})
+
+function isPaused (socket) {
+  return !socket._readableState.flowing // TODO: replace with isPaused after https://github.com/substack/node-browserify/issues/1341
+}
+
+test('Pause on connect', function (t) {
+  var server = net.createServer({pauseOnConnect: true})
+  var socket
+  server.listen(0, '127.0.0.1')
+  server.on('connection', function (con) {
+    con.on('data', function () {})
+    t.ok(isPaused(con), 'isPaused() returns true for incoming socket')
+    socket.destroy()
+    server.close()
+    t.end()
+  })
+  server.on('listening', function () {
+    t.ok(server.address().port, 'a port was assigned')
+    socket = net.connect(server.address().port, '127.0.0.1')
+  })
+})
+
+test('Pause on connect = false', function (t) {
+  var server = net.createServer()
+  var socket
+  server.listen(0, '127.0.0.1')
+  server.on('connection', function (con) {
+    con.on('data', function () {})
+    t.ok(!isPaused(con), 'isPaused() returns false for incoming socket')
+    t.ok(!isPaused(socket), 'isPaused() returns false for outgoing socket')
+    socket.destroy()
+    server.close()
+    t.end()
+  })
+  server.on('listening', function () {
+    t.ok(server.address().port, 'a port was assigned')
+    socket = net.connect(server.address().port, '127.0.0.1')
+    socket.on('data', function () {})
+  })
+})
+
+test('server only emits close when 0 connections', function (t) {
+  var socketClosed = false
+  var server = net.createServer().listen(PORT0, '127.0.0.1')
+  server.on('listening', function () {
+    var socket = net.connect(PORT0, '127.0.0.1')
+    socket.once('connect', function () {
+      server.close()
+      setTimeout(function () {
+        socket.destroy()
+        socketClosed = true
+      }, 300)
+    })
+  })
+  server.on('close', function () {
+    t.ok(socketClosed, 'socket is closed on server close event')
+    t.end()
+  })
+  server.on('connection', function (con) {
+    con.resume() // allow FIN to be received
+  })
+})
+
+test('IPv4/v6 for listen', function (t) {
+  var server = net.createServer().listen(0, '127.0.0.1')
+  server.once('listening', function () {
+    t.equal(server.address().family, 'IPv4')
+    server.listen(0, '::1')
+    server.once('listening', function () {
+      t.equal(server.address().family, 'IPv6')
+      server.close()
+      t.end()
+    })
+  })
+  server.on('error', function (error) {
+    t.error(error)
+    server.close()
+    t.end()
+  })
+})
+
+test('IPv4/v6 for connect', function (t) {
+  var server = net.createServer().listen(PORT0, '::0')
+  server.once('listening', function () {
+    var socket = net.connect(PORT0, '127.0.0.1')
+    socket.once('connect', function () {
+      t.equal(socket.remoteFamily, 'IPv4')
+      socket.connect(PORT0, '::1')
+      socket.once('connect', function () {
+        t.equal(socket.remoteFamily, 'IPv6')
+        socket.destroy()
+        server.close()
+        t.end()
+      })
+    })
+    socket.on('error', function (error) {
+      t.error(error)
+      socket.destroy()
+      server.close()
+      t.end()
+    })
+  })
+})
+
+test('socket setTimeout', function (t) {
+  var server = net.createServer().listen(PORT0, '127.0.0.1')
+  server.once('listening', function () {
+    var socket = net.connect(PORT0, '127.0.0.1')
+    var timeoutExpected = false
+    socket.setTimeout(100, function () {
+      t.ok(timeoutExpected, 'Timeout is expected')
+      socket.destroy()
+      server.close()
+      t.end()
+    })
+
+    setTimeout(function () {
+      socket.write('Ping')
+    }, 60)
+    socket.on('data', function () {
+      setTimeout(function () {
+        timeoutExpected = true
+      }, 60)
+    })
+
+    server.on('connection', function (con) {
+      con.on('data', function () {
+        setTimeout(function () {
+          con.write('Pong')
+        }, 60)
+      })
+    })
+  })
+})

--- a/test/client/tcp-connect-direct.js
+++ b/test/client/tcp-connect-direct.js
@@ -1,4 +1,4 @@
-var net = require('../../')
+var net = require('net')
 
 var PORT = Number(process.env.PORT)
 

--- a/test/client/tcp-connect.js
+++ b/test/client/tcp-connect.js
@@ -1,4 +1,4 @@
-var net = require('../../')
+var net = require('net')
 
 var PORT = Number(process.env.PORT)
 

--- a/test/client/tcp-listen.js
+++ b/test/client/tcp-listen.js
@@ -1,5 +1,5 @@
-var dgram = require('chrome-dgram')
-var net = require('../../')
+var dgram = require('dgram')
+var net = require('net')
 
 var LISTEN_PORT = Number(process.env.LISTEN_PORT)
 var READY_PORT = Number(process.env.READY_PORT)

--- a/test/client/tcp-send-buffer.js
+++ b/test/client/tcp-send-buffer.js
@@ -1,4 +1,4 @@
-var net = require('../../')
+var net = require('net')
 var Buffer = require('buffer').Buffer
 
 var PORT = Number(process.env.PORT)

--- a/test/helper.js
+++ b/test/helper.js
@@ -1,4 +1,5 @@
 var browserify = require('browserify')
+var builtins = require('browserify/lib/builtins.js')
 var cp = require('child_process')
 var envify = require('envify/custom')
 var fs = require('fs')
@@ -15,6 +16,9 @@ if (process.env.CHROME) {
 }
 
 var BUNDLE_PATH = path.join(__dirname, 'chrome-app/bundle.js')
+
+builtins.net = require.resolve('../')
+builtins.dgram = require.resolve('chrome-dgram')
 
 exports.browserify = function (filename, env, cb) {
   if (!env) env = {}

--- a/test/helper.js
+++ b/test/helper.js
@@ -5,7 +5,15 @@ var fs = require('fs')
 var once = require('once')
 var path = require('path')
 
-var CHROME = process.env.CHROME || '/Applications/Google\\ Chrome\\ Canary.app/Contents/MacOS/Google\\ Chrome\\ Canary'
+var CHROME
+if (process.env.CHROME) {
+  CHROME = process.env.CHROME
+} else if (process.platform === 'win32') {
+  CHROME = '"%ProgramFiles(x86)%\\Google\\Chrome\\Application\\chrome.exe"'
+} else {
+  CHROME = '/Applications/Google\\ Chrome\\ Canary.app/Contents/MacOS/Google\\ Chrome\\ Canary'
+}
+
 var BUNDLE_PATH = path.join(__dirname, 'chrome-app/bundle.js')
 
 exports.browserify = function (filename, env, cb) {

--- a/test/ip.js
+++ b/test/ip.js
@@ -2,9 +2,11 @@ var chromeNet = require('../')
 var test = require('tape')
 
 test('net.isIP', function (t) {
-  t.ok(chromeNet.isIP('1.2.3.4'))
-  t.ok(chromeNet.isIP('2001:0db8:3c4d:0015:0000:0000:abcd:ef12'))
+  t.ok(chromeNet.isIP('1.2.3.4') === 4)
+  t.ok(chromeNet.isIP('2001:0db8:3c4d:0015:0000:0000:abcd:ef12') === 6)
 
+  t.ok(chromeNet.isIP('260.0.0.0') === 0)
+  t.ok(chromeNet.isIP('2001:0db8:3c4d:0015:0000:0000:abcd:ef12:0000') === 0)
   t.ok(!chromeNet.isIP(''))
   t.ok(!chromeNet.isIP('abc'))
   t.ok(!chromeNet.isIP(undefined))

--- a/test/tcp-tape.js
+++ b/test/tcp-tape.js
@@ -1,0 +1,54 @@
+var auto = require('run-auto')
+var helper = require('./helper')
+var net = require('net')
+var portfinder = require('portfinder')
+var test = require('tape')
+
+test('tape running on Chrome App', function (t) {
+  auto({
+    tapePort: function (cb) {
+      portfinder.getPort(cb)
+    },
+    port0: function (cb) {
+      portfinder.getPort(cb)
+    },
+    port1: function (cb) {
+      portfinder.getPort(cb)
+    }
+  }, function (err, r) {
+    t.error(err, 'Found free ports')
+    var child
+
+    var server = net.createServer()
+
+    server.on('listening', function () {
+      var env = {TAPE_PORT: r.tapePort, PORT0: r.port0, PORT1: r.port1}
+      helper.browserify('tape-helper.js', env, function (err) {
+        t.error(err, 'Clean browserify build')
+        child = helper.launchBrowser()
+      })
+    })
+
+    server.on('connection', function (c) {
+      console.log('\noutput from tape on Chrome ------------------------------')
+      c.on('data', function (data) {
+        data = JSON.parse(data) // TODO: this sometimes fails when two JSON objects arrive in the same packet
+        switch (data.op) {
+          case 'log':
+            process.stdout.write(data.log)
+            break
+          case 'end':
+            console.log('end output from tape on Chrome --------------------------\n')
+            t.ok(data.success, 'all tests on Chrome App passed')
+            c.end()
+            server.close()
+            child.kill()
+            t.end()
+            break
+        }
+      })
+    })
+
+    server.listen(r.tapePort)
+  })
+})


### PR DESCRIPTION
Some time ago I made [jscissr/net-chrome-apps](https://github.com/jscissr/net-chrome-apps) without knowing that you already did exactly the same thing... until jscissr/net-chrome-apps#1.
Because there is really no big difference (except that you have tests), I decided to merge in the parts of my version which are better, and I also made some other improvements in the process.

This patch results in higher compatibility to the original node module. For example the error codes of Chrome are now mapped to the UV/Node codes. Servers only emit `close` when they are closed, not starting up and no clients are connected anymore.
More edge cases are caught; there is now a check that the `id` is still the same as before in every callback (unexpected things may happen between an async call).
Tests now run directly in the Chrome App, the tape output is simply piped through a socket to the console.
I replaced ipaddr.js with a (complicated) regex, I don't think there should be another library in the deps just for some rarely used function for compatibility.