### PR TITLE
Thorough check for Chrome App enviroment

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ var servers = {}
 var sockets = {}
 
 // Thorough check for Chrome App since both Edge and Chrome implement dummy chrome object
-if (typeof chrome == 'object' && typeof chrome.runtime == 'object' && typeof chrome.runtime.id == 'string') {
+if (typeof chrome === 'object' && typeof chrome.runtime === 'object' && typeof chrome.runtime.id === 'string') {
   chrome.sockets.tcpServer.onAccept.addListener(onAccept)
   chrome.sockets.tcpServer.onAcceptError.addListener(onAcceptError)
   chrome.sockets.tcp.onReceive.addListener(onReceive)

--- a/index.js
+++ b/index.js
@@ -21,7 +21,8 @@ var timers = require('timers')
 var servers = {}
 var sockets = {}
 
-if (typeof chrome !== 'undefined') {
+// Thorough check for Chrome App since both Edge and Chrome implement dummy chrome object
+if (typeof chrome == 'object' && typeof chrome.runtime == 'object' && typeof chrome.runtime.id == 'string') {
   chrome.sockets.tcpServer.onAccept.addListener(onAccept)
   chrome.sockets.tcpServer.onAcceptError.addListener(onAcceptError)
   chrome.sockets.tcp.onReceive.addListener(onReceive)


### PR DESCRIPTION
Both Edge and Chrome (in browser, níž just apps) implements dummy chrome object which leads to errors when used outside Chrome App enviroment.

I wrote a module flexus-net which wraps chrome-net and winrt-net for easier use in JSPM but it evaluates both modules leading to errors in Windows Apps since there's the dummy chrome object for some reason and simply checking for typeof chrome to be object is not sufficient