### PR TITLE
Don't increment bytesRead or unrefTimers if socket is paused

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# chrome-net
+# cordova-chrome-net
 
 ### Use the Node `net` API in cordova Apps with the chrome-socket plugins
 
@@ -11,7 +11,7 @@ This module is used by [cordova-bitcore](https://github.com/theveloped/cordova-b
 ## install
 
 ```
-npm install chrome-net
+npm install cordova-chrome-net
 ```
 
 ## methods

--- a/README.md
+++ b/README.md
@@ -64,4 +64,4 @@ See nodejs.org for full API documentation: [net](http://nodejs.org/api/net.html)
 
 ## license
 
-MIT. Copyright (c) [Feross Aboukhadijeh](http://feross.org) & John Hiesey.
+MIT. Copyright (c) Tobias Scheepers, Feross Aboukhadijeh and John Hiesey.

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# chrome-net [![npm](https://img.shields.io/npm/v/chrome-net.svg)](https://npmjs.org/package/chrome-net) [![downloads](https://img.shields.io/npm/dm/chrome-net.svg)](https://npmjs.org/package/chrome-net)
+# chrome-net
 
-### Use the Node `net` API in Chrome Apps
+### Use the Node `net` API in cordova Apps with the chrome-socket plugins
 
-This module lets you use the Node.js [net](http://nodejs.org/api/net.html) (TCP) API in [Chrome Packaged Apps](http://developer.chrome.com/apps/about_apps.html).
+This module lets you use the Node.js [net](http://nodejs.org/api/net.html) (TCP) API in cordova/ionic mobile apps using `cordova-plugin-chrome-apps-sockets-tcp` and `cordova-plugin-chrome-apps-sockets-tcpserver` plugins for cordova.
 
 Instead of learning the quirks of Chrome's `chrome.sockets` API for networking in Chrome Apps just **use the higher-level node API you're familiar with**. Then, compile your code with [browserify](https://github.com/substack/node-browserify) and you're all set!
 
-This module is used by [webtorrent](https://github.com/feross/webtorrent).
+This module is used by [cordova-bitcore](https://github.com/theveloped/cordova-bitcore.git).
 
 ## install
 
@@ -61,10 +61,6 @@ server.listen(1337)
 ```
 
 See nodejs.org for full API documentation: [net](http://nodejs.org/api/net.html)
-
-## contribute
-
-To run tests, use `npm test`. The tests will run TCP and UDP servers and launch a few different Chrome Packaged Apps with browserified client code. The tests currently require Chrome Canary on Mac. If you're on Windows or Linux, feel free to send a pull request to fix this limitation.
 
 ## license
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Use node's `net` API, including all parameter list shorthands and variations.
 Example TCP client:
 
 ```js
-var net = require('chrome-net')
+var net = require('cordova-chrome-net')
 
 var client = net.createConnection({
   port: 1337,
@@ -41,7 +41,7 @@ client.on('data', function (data) {
 Example TCP server:
 
 ```js
-var net = require('chrome-net')
+var net = require('cordova-chrome-net')
 
 var server = net.createServer()
 

--- a/index.js
+++ b/index.js
@@ -20,13 +20,14 @@ var timers = require('timers')
 // to the right handlers.
 var servers = {}
 var sockets = {}
+var listenersAdded = false
 
-if (typeof chrome !== 'undefined') {
-  chrome.sockets.tcpServer.onAccept.addListener(onAccept)
-  chrome.sockets.tcpServer.onAcceptError.addListener(onAcceptError)
-  chrome.sockets.tcp.onReceive.addListener(onReceive)
-  chrome.sockets.tcp.onReceiveError.addListener(onReceiveError)
-}
+// if (typeof chrome !== 'undefined') {
+//   chrome.sockets.tcpServer.onAccept.addListener(onAccept)
+//   chrome.sockets.tcpServer.onAcceptError.addListener(onAcceptError)
+//   chrome.sockets.tcp.onReceive.addListener(onReceive)
+//   chrome.sockets.tcp.onReceiveError.addListener(onReceiveError)
+// }
 
 function onAccept (info) {
   if (info.socketId in servers) {
@@ -133,6 +134,16 @@ function Server (/* [options], listener */) {
   var self = this
   if (!(self instanceof Server)) return new Server(arguments[0], arguments[1])
   EventEmitter.call(self)
+  
+  if (!listenersAdded) {
+    if (typeof chrome !== 'undefined') {
+      chrome.sockets.tcpServer.onAccept.addListener(onAccept)
+      chrome.sockets.tcpServer.onAcceptError.addListener(onAcceptError)
+      chrome.sockets.tcp.onReceive.addListener(onReceive)
+      chrome.sockets.tcp.onReceiveError.addListener(onReceiveError)
+      listenersAdded = true
+    }
+  }
 
   var options
 
@@ -518,6 +529,16 @@ inherits(Socket, stream.Duplex)
 function Socket (options) {
   var self = this
   if (!(self instanceof Socket)) return new Socket(options)
+
+  if (!listenersAdded) {
+    if (typeof chrome !== 'undefined') {
+      chrome.sockets.tcpServer.onAccept.addListener(onAccept)
+      chrome.sockets.tcpServer.onAcceptError.addListener(onAcceptError)
+      chrome.sockets.tcp.onReceive.addListener(onReceive)
+      chrome.sockets.tcp.onReceiveError.addListener(onReceiveError)
+      listenersAdded = true
+    }
+  }
 
   if (is.isNumber(options)) {
     options = { fd: options } // Legacy interface.

--- a/index.js
+++ b/index.js
@@ -134,7 +134,7 @@ function Server (/* [options], listener */) {
   var self = this
   if (!(self instanceof Server)) return new Server(arguments[0], arguments[1])
   EventEmitter.call(self)
-  
+
   if (!listenersAdded) {
     if (typeof chrome !== 'undefined') {
       chrome.sockets.tcpServer.onAccept.addListener(onAccept)
@@ -1146,9 +1146,10 @@ var errorChromeToUv = {
   '-138': 'EACCES',
   '-147': 'EADDRINUSE',
   '-108': 'EADDRNOTAVAIL',
+  '-104': 'ECONNRESET',
   '-103': 'ECONNABORTED',
-  '-102': 'ECONNREFUSED',
-  '-101': 'ECONNRESET',
+  '-102': 'ENETRESET',
+  '-101': 'ENETUNREACH',
   '-16': 'EEXIST',
   '-8': 'EFBIG',
   '-109': 'EHOSTUNREACH',

--- a/package.json
+++ b/package.json
@@ -1,12 +1,13 @@
 {
-  "name": "chrome-net",
-  "description": "Use the Node `net` API in Chrome Apps",
-  "version": "3.0.1",
-  "author": "Feross Aboukhadijeh <feross@feross.org> (http://feross.org/)",
+  "name": "cordova-chrome-net",
+  "description": "Use the Node `net` API in cordova Apps",
+  "version": "1.0.0",
+  "author": "Tobias Scheepers <tobias.scheepers@gmail.com> (https://github.com/theveloped)",
   "bugs": {
-    "url": "https://github.com/feross/chrome-net/issues"
+    "url": "https://github.com/theveloped/cordova-chrome-net/issues"
   },
   "contributors": [
+    "Feross Aboukhadijeh <feross@feross.org> (http://feross.org/)",
     "John Hiesey <john@hiesey.com>"
   ],
   "dependencies": {
@@ -24,8 +25,10 @@
     "tape": "^4.0.0",
     "through": "2.x"
   },
-  "homepage": "https://github.com/feross/chrome-net",
+  "homepage": "https://github.com/theveloped/cordova-chrome-net",
   "keywords": [
+    "cordova",
+    "ionic",
     "chrome app",
     "chrome.socket",
     "socket api",
@@ -39,9 +42,8 @@
   "main": "index.js",
   "repository": {
     "type": "git",
-    "url": "git://github.com/feross/chrome-net.git"
+    "url": "git://github.com/theveloped/cordova-chrome-net"
   },
   "scripts": {
-    "test": "standard && tape test/*.js"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cordova-chrome-net",
   "description": "Use the Node `net` API in cordova Apps",
-  "version": "1.0.1",
+  "version": "1.0.3",
   "author": "Tobias Scheepers <tobias.scheepers@gmail.com> (https://github.com/theveloped)",
   "bugs": {
     "url": "https://github.com/theveloped/cordova-chrome-net/issues"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cordova-chrome-net",
   "description": "Use the Node `net` API in cordova Apps",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": "Tobias Scheepers <tobias.scheepers@gmail.com> (https://github.com/theveloped)",
   "bugs": {
     "url": "https://github.com/theveloped/cordova-chrome-net/issues"


### PR DESCRIPTION
When TCP buffers get full such that `this.push(buffer)` fails, the `onReceive` handler will be called again with the same data.  But because `chrome-net` increments its buffers and calls `_unrefTimer()` anyway, even if the data was not accepted into the stream's buffer.

The result is a corrupted data stream, if the sender ever fills your TCP buffer fully and has to back off.

The following patch fixes that.

Also added a couple of missing error codes...