### PR TITLE
destroy callback not getting called

### DIFF
--- a/index.js
+++ b/index.js
@@ -782,7 +782,7 @@ Socket.prototype._write = function (chunk, encoding, callback) {
     }
 
     if (sendInfo.resultCode < 0) {
-      this.destroy(exceptionWithHostPort(sendInfo.resultCode, 'write', this.remoteAddress, this.remotePort), callback)
+      this._destroy(exceptionWithHostPort(sendInfo.resultCode, 'write', this.remoteAddress, this.remotePort), callback)
     } else {
       this._unrefTimer()
       callback(null)


### PR DESCRIPTION
On line 786 this.destroy was called however the callback isn't passed to _destroy so is never processed. I changed to call _destroy directly which accepts the callback argument.