### PR TITLE
Improved feature-detection of chrome.sockets

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,6 @@ if (
   typeof chrome.runtime.id === 'string' &&
   typeof chrome.sockets === 'object' &&
   typeof chrome.sockets.tcpServer === 'object' &&
-  typeof chrome.sockets === 'object' &&
   typeof chrome.sockets.tcp === 'object'
 ) {
   chrome.sockets.tcpServer.onAccept.addListener(onAccept)

--- a/index.js
+++ b/index.js
@@ -23,7 +23,15 @@ var servers = {}
 var sockets = {}
 
 // Thorough check for Chrome App since both Edge and Chrome implement dummy chrome object
-if (typeof chrome === 'object' && typeof chrome.runtime === 'object' && typeof chrome.runtime.id === 'string') {
+if (
+  typeof chrome === 'object' &&
+  typeof chrome.runtime === 'object' &&
+  typeof chrome.runtime.id === 'string' &&
+  typeof chrome.sockets === 'object' &&
+  typeof chrome.sockets.tcpServer === 'object' &&
+  typeof chrome.sockets === 'object' &&
+  typeof chrome.sockets.tcp === 'object'
+) {
   chrome.sockets.tcpServer.onAccept.addListener(onAccept)
   chrome.sockets.tcpServer.onAcceptError.addListener(onAcceptError)
   chrome.sockets.tcp.onReceive.addListener(onReceive)


### PR DESCRIPTION
## What?

This PR adds explicit check if `chrome.sockets.tcp` and `chrome.sockets.tcpServer` exist before registering related listeners.

## Why?

`chrome-net` did not check if used `chrome.sockets.*` APIs actually exist, which caused problems in browser extensions. Extension was unable to maintain the single codebase and do feature-detection at runtime (eg. Google Chrome without `chrome.sockets` vs Brave with).  

This PR makes it possible to include `chrome-net` in generic build pipeline.

Refs. https://github.com/ipfs-shipyard/ipfs-companion/issues/664 https://github.com/ipfs-shipyard/ipfs-companion/issues/716

