### PR TITLE
Use object shorthand for properties

### DIFF
--- a/test/client/tape-helper.js
+++ b/test/client/tape-helper.js
@@ -10,7 +10,7 @@ test.createStream().on('data', function (log) {
   con.write(JSON.stringify({ op: 'log', log: log.toString() }) + '\n')
   success = log === '\n# ok\n'
 }).on('end', function () {
-  con.write(JSON.stringify({ op: 'end', success: success }) + '\n')
+  con.write(JSON.stringify({ op: 'end', success }) + '\n')
   con.end()
 })
 


### PR DESCRIPTION
This rule is on its way into the latest Standard ☺️ 

ref: https://github.com/standard/eslint-config-standard/pull/166

Compatibility: This has been supported since Chrome 43, released in 2015